### PR TITLE
Define QETpy version in package for easy checking

### DIFF
--- a/qetpy/__init__.py
+++ b/qetpy/__init__.py
@@ -5,3 +5,5 @@ from .cut import autocuts, IterCut
 from . import plotting
 from . import sim
 from . import utils
+from ._version import __version__
+

--- a/qetpy/_version.py
+++ b/qetpy/_version.py
@@ -1,0 +1,2 @@
+# special file for defining the current version of the package
+__version__ = "1.5.0"

--- a/setup.py
+++ b/setup.py
@@ -2,12 +2,28 @@ import os
 import glob
 import shutil
 from setuptools import setup, find_packages, Command
+import codecs
 
 # read the contents of your README file
 from os import path
 this_directory = path.abspath(path.dirname(__file__))
 with open(path.join(this_directory, 'README.md'), encoding='utf-8') as f:
     long_description = f.read()
+
+# set up automated versioning reading    
+def read(rel_path):
+    here = os.path.abspath(os.path.dirname(__file__))
+    with codecs.open(os.path.join(here, rel_path), 'r') as fp:
+        return fp.read()
+
+def get_version(rel_path):
+    for line in read(rel_path).splitlines():
+        if line.startswith('__version__'):
+            delim = '"' if '"' in line else "'"
+            return line.split(delim)[1]
+    else:
+        raise RuntimeError("Unable to find version string.")
+
 
 class CleanCommand(Command):
     """Custom clean command to tidy up the project root."""
@@ -36,7 +52,7 @@ class CleanCommand(Command):
 
 setup(
     name="QETpy",
-    version="1.5.0",
+    version=get_version('qetpy/_version.py'),
     description="TES Detector Calibration and Analysis Python Tools",
     long_description=long_description,
     long_description_content_type='text/markdown',


### PR DESCRIPTION
I added a new file `qetpy/_version.py`, which stores the current version of the package (this should be updated before any new release). The `setup.py` file will load the version via this, rather than being defined in the `setup.py` file, and we only need to update the `_version.py` file.