### PR TITLE
Feature/calibrated offsets

### DIFF
--- a/qetpy/core/didv/_base_didv.py
+++ b/qetpy/core/didv/_base_didv.py
@@ -381,7 +381,7 @@ def squarewaveresponse(t, sgamp, sgfreq, dutycycle=0.5, *, rsh=None, rp=None,
 def get_i0(offset, offset_err, offset_dict, output_offset=None,
            closed_loop_norm=None, output_gain=1,
            lgc_invert_offset=False,
-           lgc_calibration_on=True, calibration_dict=None, 
+           lgc_calibration_on=False, calibration_dict=None, 
            lgc_diagnostics=False):
     """
     Gets and returns the current and uncertainty in the current
@@ -415,7 +415,7 @@ def get_i0(offset, offset_err, offset_dict, output_offset=None,
         units of volts.
         
     lgc_calibration_on : bool, optional
-        By default True (i.e. using the calibration). If True, uses the calibration_dict
+        By default False (i.e. not using the calibration). If True, uses the calibration_dict
         to more closely approximate how changing the output_offset changes the current
         measured.
         

--- a/qetpy/core/didv/_base_didv.py
+++ b/qetpy/core/didv/_base_didv.py
@@ -451,8 +451,10 @@ def get_i0(offset, offset_err, offset_dict, output_offset=None,
         i0_variable_offset_sweep = None
         if 'i0_variable_offset' in offset_dict.keys():
             i0_variable_offset_sweep = offset_dict['i0_variable_offset']
-        elif 'i0_changable_offset' in offset_dict.keys():
-            i0_variable_offset_sweep  =  offset_dict['i0_changable_offset']
+        elif ('i0_changable_offset_cal' in offset_dict.keys()) and (lgc_calibration_on is True):
+            i0_variable_offset_sweep  =  offset_dict['i0_changable_offset_cal']
+        elif ('i0_changable_offset_uncal' in offset_dict.keys()) and (lgc_calibration_on is False):
+            i0_variable_offset_sweep  =  offset_dict['i0_changable_offset_uncal']
         else:
             raise ValueError('ERROR: i0 variable offset not found in '
                              '"ivsweep_result" dictionary!')
@@ -460,16 +462,39 @@ def get_i0(offset, offset_err, offset_dict, output_offset=None,
         # current IV variable offset
         if lgc_calibration_on is False:
             i0_variable_offset = output_offset * output_gain/closed_loop_norm
+            
         else:
             if calibration_dict is None:
                 raise ValueError('ERROR: must include calibration_dict if '
-                                 'lgc_calibration_on is True (i.e. being used)!')
+                                 'lgc_calibration_on is True (i.e. being used)!'
+                                 'Check offset dicts')
+                                 
+            elif (output_gain != 50):
+                raise ValueError('ERROR: calibration only done for a gain of 50')
+                
             elif (calibration_dict['model'] == 'twopartlinear'):
                 m1, m2, b1, b2 = calibration_dict['params']
                 if output_offset > 0.0:
                     i0_variable_offset = output_offset * m1 + b1
                 else:
                     i0_variable_offset = output_offset * m2 + b2
+                    
+            elif (calibration_dict['model'] == 'lookup_extrapolated'):
+                offsets_arr = calibration_dict['params']['lookup_x']
+                currents_arr = calibration_dict['params']['lookup_y']
+                params_low = calibration_dict['params']['params_low']
+                params_high = calibration_dict['params']['params_high']
+                
+                def linear(x, m, b):
+                    return x*m + b
+                
+                if output_offset in offsets_arr:
+                    i0_variable_offset = currents_arr[list(offsets_arr).index(offset)]
+                elif output_offset > 0.0:
+                    i0_variable_offset = linear(output_offset, *params_high)
+                else:
+                    i0_variable_offset = linear(output_offset, *params_low)
+                    
             else:
                 raise ValueError('ERROR: unknown calibration_dict model')
             
@@ -490,11 +515,11 @@ def get_i0(offset, offset_err, offset_dict, output_offset=None,
             print(" ")
 
     # calculate new i0
-    current_didv = offset - delta_i_variable
+    current_didv = offset
     if lgc_invert_offset:
         current_didv = -current_didv
     current_err_didv = offset_err
-    i0 = current_didv - offset_dict['i0_off']
+    i0 = current_didv - delta_i_variable - offset_dict['i0_off']
     
     if lgc_diagnostics:
         print("Current as measured from dIdV: " + str(current_didv) + " amps")

--- a/qetpy/core/didv/_base_didv.py
+++ b/qetpy/core/didv/_base_didv.py
@@ -381,6 +381,7 @@ def squarewaveresponse(t, sgamp, sgfreq, dutycycle=0.5, *, rsh=None, rp=None,
 def get_i0(offset, offset_err, offset_dict, output_offset=None,
            closed_loop_norm=None, output_gain=1,
            lgc_invert_offset=False,
+           lgc_calibration_on=True, calibration_dict=None, 
            lgc_diagnostics=False):
     """
     Gets and returns the current and uncertainty in the current
@@ -412,6 +413,15 @@ def get_i0(offset, offset_err, offset_dict, output_offset=None,
         The dimensionless gain for the front end electronics. Used to translate the
         output_offset in units of volts to the equivilant value read in the DAQ in
         units of volts.
+        
+    lgc_calibration_on : bool, optional
+        By default True (i.e. using the calibration). If True, uses the calibration_dict
+        to more closely approximate how changing the output_offset changes the current
+        measured.
+        
+    calibration_dict : dict, optional
+        A dictonary of data used to more closely model the relationship between the
+        output_offset and the change in the measured current in the device. 
         
     lgc_diagnostics : bool, optional
         Used if you want to see the raw currents and offsets and how they're
@@ -448,7 +458,21 @@ def get_i0(offset, offset_err, offset_dict, output_offset=None,
                              '"ivsweep_result" dictionary!')
 
         # current IV variable offset
-        i0_variable_offset = output_offset * output_gain/closed_loop_norm
+        if lgc_calibration_on is False:
+            i0_variable_offset = output_offset * output_gain/closed_loop_norm
+        else:
+            if calibration_dict is None:
+                raise ValueError('ERROR: must include calibration_dict if '
+                                 'lgc_calibration_on is True (i.e. being used)!')
+            elif (calibration_dict['model'] == 'twopartlinear'):
+                m1, m2, b1, b2 = calibration_dict['params']
+                if output_offset > 0.0:
+                    i0_variable_offset = output_offset * m1 + b1
+                else:
+                    i0_variable_offset = output_offset * m2 + b2
+            else:
+                raise ValueError('ERROR: unknown calibration_dict model')
+            
        
         # delta variable offset
         delta_i_variable = i0_variable_offset - i0_variable_offset_sweep

--- a/qetpy/core/didv/_didv.py
+++ b/qetpy/core/didv/_didv.py
@@ -1083,7 +1083,8 @@ class DIDV(_BaseDIDV, _PlotDIDV):
                                 ibias_metadata,
                                 bounds=None, guess=None,
                                 inf_loop_gain_approx=False,
-                                inf_loop_gain_limit=False, 
+                                inf_loop_gain_limit=False,
+                                lgc_calibration_on=True, calibration_dict=None, 
                                 lgcdiagnostics=False):
         """
         Given the offset dictionary used to store the various current
@@ -1131,6 +1132,15 @@ class DIDV(_BaseDIDV, _PlotDIDV):
             Defaults to False. If True, calculates the biasparameters and the
             rest of the fits using the infinite loop gain approximation only if
             the fit loopgain is negative.
+
+        lgc_calibration_on : bool, optional
+            By default True (i.e. using the calibration). If True, uses the calibration_dict
+            to more closely approximate how changing the output_offset changes the current
+            measured.
+            
+        calibration_dict : dict, optional
+            A dictonary of data used to more closely model the relationship between the
+            output_offset and the change in the measured current in the device. 
         
         Returns:
         --------
@@ -1150,7 +1160,8 @@ class DIDV(_BaseDIDV, _PlotDIDV):
         offset_err = self._offset_err
 
         i0, i0_err = get_i0(offset, offset_err, offset_dict, output_offset,
-                            closed_loop_norm, output_gain, lgcdiagnostics)
+                            closed_loop_norm, output_gain, lgcdiagnostics,
+                            lgc_calibration_on=lgc_calibration_on, calibration_dict=calibration_dict)
         ibias, ibias_err = get_ibias(ibias_metadata, offset_dict, lgcdiagnostics)
         biasparams_dict = get_tes_bias_parameters_dict(i0, i0_err, ibias, ibias_err, rsh, rp)
         

--- a/qetpy/core/didv/_didv.py
+++ b/qetpy/core/didv/_didv.py
@@ -1084,7 +1084,7 @@ class DIDV(_BaseDIDV, _PlotDIDV):
                                 bounds=None, guess=None,
                                 inf_loop_gain_approx=False,
                                 inf_loop_gain_limit=False,
-                                lgc_calibration_on=True, calibration_dict=None, 
+                                lgc_calibration_on=True,
                                 lgcdiagnostics=False):
         """
         Given the offset dictionary used to store the various current
@@ -1137,10 +1137,6 @@ class DIDV(_BaseDIDV, _PlotDIDV):
             By default True (i.e. using the calibration). If True, uses the calibration_dict
             to more closely approximate how changing the output_offset changes the current
             measured.
-            
-        calibration_dict : dict, optional
-            A dictonary of data used to more closely model the relationship between the
-            output_offset and the change in the measured current in the device. 
         
         Returns:
         --------
@@ -1158,15 +1154,20 @@ class DIDV(_BaseDIDV, _PlotDIDV):
 
         offset = self._offset
         offset_err = self._offset_err
+        
+        if 'calibration_dict' in offset_dict:
+            calibration_dict = offset_dict['calibration_dict']
+        else:
+            calibration_dict = None
 
         i0, i0_err = get_i0(offset, offset_err, offset_dict, output_offset,
-                            closed_loop_norm, output_gain, lgcdiagnostics,
+                            closed_loop_norm, output_gain, lgc_diagnostics=lgcdiagnostics,
                             lgc_calibration_on=lgc_calibration_on, calibration_dict=calibration_dict)
-        ibias, ibias_err = get_ibias(ibias_metadata, offset_dict, lgcdiagnostics)
+        ibias, ibias_err = get_ibias(ibias_metadata, offset_dict, lgc_diagnostics=lgcdiagnostics)
         biasparams_dict = get_tes_bias_parameters_dict(i0, i0_err, ibias, ibias_err, rsh, rp)
         
         if inf_loop_gain_approx:
-            biasparams_dict = get_tes_bias_parameters_dict_infinite_loop_gain(
+            biasparams_dict = get_tes_bias_parameters_dict_infinite_loop_gain(3, 
                 self._3poleresult['params'], self._3poleresult['cov'],
                 ibias, ibias_err, rsh, rp)
         
@@ -1178,7 +1179,7 @@ class DIDV(_BaseDIDV, _PlotDIDV):
                              
         if inf_loop_gain_limit:
             if self._3poleresult['smallsignalparams']['l'] < 0:
-                biasparams_dict = get_tes_bias_parameters_dict_infinite_loop_gain(
+                biasparams_dict = get_tes_bias_parameters_dict_infinite_loop_gain(3, 
                     self._3poleresult['params'], 
                     self._3poleresult['cov'], i0, 
                     i0_err, ibias, ibias_err, 

--- a/qetpy/core/didv/_didv.py
+++ b/qetpy/core/didv/_didv.py
@@ -1084,7 +1084,7 @@ class DIDV(_BaseDIDV, _PlotDIDV):
                                 bounds=None, guess=None,
                                 inf_loop_gain_approx=False,
                                 inf_loop_gain_limit=False,
-                                lgc_calibration_on=True,
+                                lgc_calibration_on=False,
                                 lgcdiagnostics=False):
         """
         Given the offset dictionary used to store the various current
@@ -1134,7 +1134,7 @@ class DIDV(_BaseDIDV, _PlotDIDV):
             the fit loopgain is negative.
 
         lgc_calibration_on : bool, optional
-            By default True (i.e. using the calibration). If True, uses the calibration_dict
+            By default False (i.e. not using the calibration). If True, uses the calibration_dict
             to more closely approximate how changing the output_offset changes the current
             measured.
         


### PR DESCRIPTION
Fixed: there was an issue with the infinite loop gain aproximation calculation that prevented it from proceeding correctly.

Added: we can now use a calibrated correction for nonlinearities in the FEB output gain. There are also associated updates to pytesdaq for generating offset dicts using the new calibrated correction.