### PR TITLE
Noise trace generation from CSD

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.7", "3.8", "3.9"]
+        python-version: ["3.9", "3.10"]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10"]
+        python-version: ["3.10","3.11"]
 
     steps:
     - uses: actions/checkout@v2

--- a/qetpy/core/_noise.py
+++ b/qetpy/core/_noise.py
@@ -365,8 +365,8 @@ def gen_noise(csd, fs=1.0, n_traces=1):
         L = np.linalg.cholesky(csd[:, :, i] * dfreq)
 
         # Generate standard normal random variables (mean=0, variance=1)
-        z = np.random.normal(size=(n_channels, n_iterations)) + \
-            1j * np.random.normal(size=(n_channels, n_iterations))
+        z = np.random.normal(size=(n_channels, n_traces)) + \
+            1j * np.random.normal(size=(n_channels, n_traces))
         z *= 1 / np.sqrt(2)
 
         # Get the desired distribution of Fourier amplitudes

--- a/qetpy/core/_noise.py
+++ b/qetpy/core/_noise.py
@@ -13,7 +13,9 @@ from qetpy.utils import fft, ifft, fftfreq, rfftfreq
 
 __all__ = ["foldpsd", "foldcsd", "calc_psd",
            "calc_csd","calc_corrcoeff_from_csd",
-           "smooth_psd", "gen_noise", "Noise"]
+           "smooth_psd", "gen_noise",
+           "gen_noise_from_psd",
+           "Noise"]
 
 
 def foldpsd(psd, fs):

--- a/qetpy/core/_noise.py
+++ b/qetpy/core/_noise.py
@@ -278,7 +278,7 @@ def smooth_psd(psd):
     
     return psd_out
 
-def gen_noise_old(psd, fs=1.0, ntraces=1):
+def gen_noise_from_psd(psd, fs=1.0, ntraces=1):
     """
     Function to generate noise traces with random phase from a given PSD. The PSD calculated from
     the generated noise traces should be the equivalent to the inputted PSD as the number of traces

--- a/qetpy/utils/_utils.py
+++ b/qetpy/utils/_utils.py
@@ -995,11 +995,11 @@ def energy_absorbed(trace, ioffset, qetbias, rload, rsh, fs=None,
     trace_power = powertrace_simple(trace, ioffset, qetbias, rload, rsh)
 
     if fs is not None:
-        integrated_energy = np.trapz(
+        integrated_energy = np.trapezoid(
             baseline_p0 - trace_power, axis=-1,
         ) / (fs * constants.e)
     elif time is not None:
-        integrated_energy = np.trapz(
+        integrated_energy = np.trapezoid(
             baseline_p0 - trace_power, x=time, axis=-1,
         ) / constants.e
     else:

--- a/test/helpers.py
+++ b/test/helpers.py
@@ -82,7 +82,7 @@ def create_example_data(lgcpileup=False, lgcbaseline=False):
     pulse_shifted = np.roll(pulse, len(t)//2)
     template = pulse_shifted/pulse_shifted.max()
     
-    noise = qp.gen_noise_from_psd(psd_sim, fs=fs, ntraces=1)[0]
+    noise = qp.gen_noise(psd_sim, fs=fs, n_traces=1)[0]
     signal = noise + np.roll(template, 100)*(pulse_amp)
 
     if lgcpileup:
@@ -124,7 +124,7 @@ def create_example_muontail():
     pulse = np.exp(-t/tau_fall)
     template = pulse/pulse.max()
     
-    noise = qp.gen_noise(psd_sim, fs=fs, ntraces=1)[0]
+    noise = qp.gen_noise(psd_sim, fs=fs, n_traces=1)[0]
     signal = noise + template * pulse_amp
 
     return signal, psd_sim
@@ -174,7 +174,7 @@ def create_example_pulseplusmuontail(lgcbaseline=False):
     muon_pulse = np.exp(-t/muon_fall)
     muon_template = muon_pulse/muon_pulse.max()
 
-    noise = qp.gen_noise(psd_sim, fs=fs, ntraces=1)[0]
+    noise = qp.gen_noise(psd_sim, fs=fs, n_traces=1)[0]
     signal = noise + template*PULSE_AMP + muon_template*muon_amp
 
     if lgcbaseline:
@@ -259,7 +259,7 @@ def create_example_ttl_leakage_pulses(
     backgroundpulses = backgroundtemplates@bkgamps
     backgroundpulses = backgroundpulses * bkgampscale
 
-    noise = qp.gen_noise(psd_sim, fs=fs, ntraces=1)[0]
+    noise = qp.gen_noise(psd_sim, fs=fs, n_traces=1)[0]
     signal = noise + backgroundpulses + leakagepulse
 
     if lgcbaseline:

--- a/test/helpers.py
+++ b/test/helpers.py
@@ -82,7 +82,7 @@ def create_example_data(lgcpileup=False, lgcbaseline=False):
     pulse_shifted = np.roll(pulse, len(t)//2)
     template = pulse_shifted/pulse_shifted.max()
     
-    noise = qp.gen_noise(psd_sim, fs=fs, n_traces=1)[0]
+    noise = qp.gen_noise_from_psd(psd_sim, fs=fs, ntraces=1)[0]
     signal = noise + np.roll(template, 100)*(pulse_amp)
 
     if lgcpileup:
@@ -124,7 +124,7 @@ def create_example_muontail():
     pulse = np.exp(-t/tau_fall)
     template = pulse/pulse.max()
     
-    noise = qp.gen_noise(psd_sim, fs=fs, n_traces=1)[0]
+    noise = qp.gen_noise_from_psd(psd_sim, fs=fs, ntraces=1)[0]
     signal = noise + template * pulse_amp
 
     return signal, psd_sim
@@ -174,7 +174,7 @@ def create_example_pulseplusmuontail(lgcbaseline=False):
     muon_pulse = np.exp(-t/muon_fall)
     muon_template = muon_pulse/muon_pulse.max()
 
-    noise = qp.gen_noise(psd_sim, fs=fs, n_traces=1)[0]
+    noise = qp.gen_noise_from_psd(psd_sim, fs=fs, ntraces=1)[0]
     signal = noise + template*PULSE_AMP + muon_template*muon_amp
 
     if lgcbaseline:
@@ -259,7 +259,7 @@ def create_example_ttl_leakage_pulses(
     backgroundpulses = backgroundtemplates@bkgamps
     backgroundpulses = backgroundpulses * bkgampscale
 
-    noise = qp.gen_noise(psd_sim, fs=fs, n_traces=1)[0]
+    noise = qp.gen_noise_from_psd(psd_sim, fs=fs, ntraces=1)[0]
     signal = noise + backgroundpulses + leakagepulse
 
     if lgcbaseline:

--- a/test/helpers.py
+++ b/test/helpers.py
@@ -82,7 +82,7 @@ def create_example_data(lgcpileup=False, lgcbaseline=False):
     pulse_shifted = np.roll(pulse, len(t)//2)
     template = pulse_shifted/pulse_shifted.max()
     
-    noise = qp.gen_noise(psd_sim, fs=fs, ntraces=1)[0]
+    noise = qp.gen_noise_from_psd(psd_sim, fs=fs, ntraces=1)[0]
     signal = noise + np.roll(template, 100)*(pulse_amp)
 
     if lgcpileup:

--- a/test/test_didv.py
+++ b/test/test_didv.py
@@ -35,7 +35,7 @@ def _initialize_didv(poles, sgfreq=100, autoresample=False):
     }
 
     psd_test = np.ones(int(4 * fs / sgfreq)) / tracegain**2 / 1e4
-    rawnoise = qp.gen_noise(psd_test, fs=fs, ntraces=300)
+    rawnoise = qp.gen_noise_from_psd(psd_test, fs=fs, ntraces=300)
 
     t = np.arange(rawnoise.shape[-1]) / fs
     didv_response = qp.squarewaveresponse(

--- a/test/test_didv.py
+++ b/test/test_didv.py
@@ -35,7 +35,7 @@ def _initialize_didv(poles, sgfreq=100, autoresample=False):
     }
 
     psd_test = np.ones(int(4 * fs / sgfreq)) / tracegain**2 / 1e4
-    rawnoise = qp.gen_noise_from_psd(psd_test, fs=fs, ntraces=300)
+    rawnoise = qp.gen_noise(psd_test, fs=fs, n_traces=300)
 
     t = np.arange(rawnoise.shape[-1]) / fs
     didv_response = qp.squarewaveresponse(

--- a/test/test_didv.py
+++ b/test/test_didv.py
@@ -35,7 +35,7 @@ def _initialize_didv(poles, sgfreq=100, autoresample=False):
     }
 
     psd_test = np.ones(int(4 * fs / sgfreq)) / tracegain**2 / 1e4
-    rawnoise = qp.gen_noise(psd_test, fs=fs, n_traces=300)
+    rawnoise = qp.gen_noise_from_psd(psd_test, fs=fs, ntraces=300)
 
     t = np.arange(rawnoise.shape[-1]) / fs
     didv_response = qp.squarewaveresponse(


### PR DESCRIPTION
Updated gen_noise() function to generate noise traces from an N-dimensional CSD, not just a PSD. The old function to generate noise traces from a 1-channel PSD is preserved as gen_noise_from_psd().