### PR TITLE
FP Error dIdV plotting Bug

### DIFF
--- a/qetpy/core/didv/_plot_didv.py
+++ b/qetpy/core/didv/_plot_didv.py
@@ -497,9 +497,9 @@ class _PlotDIDV(object):
 
         # remove values set with placeholder mean
         goodinds = (
-            self._didvmean != 0.5 - 0.5j
+            np.abs(self._didvmean - (0.5 - 0.5j)) > 1e-16
         ) & (
-            self._didvmean != - 0.5 + 0.5j
+            np.abs(self._didvmean - (- 0.5 + 0.5j)) > 1e-16
         )
         fitinds = self._freq > 0
         plotinds = np.logical_and(fitinds, goodinds)


### PR DESCRIPTION
Changing definition of "Good Frequencies" for plotting. Previous version required exact matching of dIdV to default value (0.5-0.5j) to avoid plotting. Floating point errors mean sometimes non-dIdV frequencies sneak through and are plot. This bug fix reduces this requirement from an exact match to a match +- some error pegged to the floating point error of complex128 objects; around 1e-16.


<img width="854" height="545" alt="image (19)" src="https://github.com/user-attachments/assets/2340f5fc-16a3-4498-a807-b771161f90d4" />
